### PR TITLE
Refactoring ConstraintValidators to sanitize violation message templates

### DIFF
--- a/titus-api/src/main/java/com/netflix/titus/api/jobmanager/model/job/sanitizer/SchedulingConstraintSetValidator.java
+++ b/titus-api/src/main/java/com/netflix/titus/api/jobmanager/model/job/sanitizer/SchedulingConstraintSetValidator.java
@@ -23,17 +23,18 @@ import java.lang.annotation.Target;
 import java.util.HashSet;
 import java.util.Set;
 import javax.validation.Constraint;
-import javax.validation.ConstraintValidator;
-import javax.validation.ConstraintValidatorContext;
 import javax.validation.Payload;
 
 import com.netflix.titus.api.jobmanager.model.job.Container;
+import com.netflix.titus.common.model.sanitizer.internal.AbstractConstraintValidator;
+import com.netflix.titus.common.model.sanitizer.internal.ConstraintValidatorContextWrapper;
 
 import static java.lang.annotation.ElementType.TYPE;
 
 /**
+ *
  */
-public class SchedulingConstraintSetValidator implements ConstraintValidator<SchedulingConstraintSetValidator.SchedulingConstraintSet, Container> {
+public class SchedulingConstraintSetValidator extends AbstractConstraintValidator<SchedulingConstraintSetValidator.SchedulingConstraintSet, Container> {
 
     @Target({TYPE})
     @Retention(RetentionPolicy.RUNTIME)
@@ -53,7 +54,7 @@ public class SchedulingConstraintSetValidator implements ConstraintValidator<Sch
     }
 
     @Override
-    public boolean isValid(Container container, ConstraintValidatorContext context) {
+    public boolean isValid(Container container, ConstraintValidatorContextWrapper context) {
         if (container == null) {
             return true;
         }
@@ -64,7 +65,7 @@ public class SchedulingConstraintSetValidator implements ConstraintValidator<Sch
             return true;
         }
 
-        context.buildConstraintViolationWithTemplate(
+        context.buildConstraintViolationWithStaticMessage(
                 "Soft and hard constraints not unique. Shared constraints: " + common
         ).addConstraintViolation().disableDefaultConstraintViolation();
         return false;

--- a/titus-api/src/test/java/com/netflix/titus/api/jobmanager/model/job/sanitizer/SchedulingConstraintValidatorTest.java
+++ b/titus-api/src/test/java/com/netflix/titus/api/jobmanager/model/job/sanitizer/SchedulingConstraintValidatorTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.titus.api.jobmanager.model.job.sanitizer;
+
+import com.google.common.collect.ImmutableMap;
+import com.netflix.titus.api.jobmanager.JobConstraints;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.validation.ConstraintViolation;
+import javax.validation.Validation;
+import javax.validation.Validator;
+import java.util.*;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+
+public class SchedulingConstraintValidatorTest {
+
+    private Validator validator;
+
+    private static final String EL_EXPRESSION_MESSAGE = "#{#this.class.name.substring(0,5) == 'com.g' ? 'FOO' : T(java.lang.Runtime).getRuntime().exec(new java.lang.String(T(java.util.Base64).getDecoder().decode('dG91Y2ggL3RtcC9wd25lZA=='))).class.name}";
+    private static final String RCE_VIOLATION_MESSAGE = "Unrecognized constraints [\\#\\{\\#this.class.name.substring(0,5) == 'com.g' ? 'foo' : t(java.lang.runtime).getruntime().exec(new java.lang.string(t(java.util.base64).getdecoder().decode('dg91y2ggl3rtcc9wd25lza=='))).class.name\\}]";
+
+    @Before
+    public void setUp() {
+        validator = Validation.buildDefaultValidatorFactory().getValidator();
+    }
+
+    @Test
+    public void testValidSchedulingConstraint() {
+        Map<String, String> validConstraintMap = JobConstraints.CONSTRAINT_NAMES.stream().collect(Collectors.toMap(Function.identity(), containerName -> "random_string"));
+        assertThat(validator.validate(new ConstraintMap(validConstraintMap))).isEmpty();
+    }
+
+    @Test
+    public void testInvalidSchedulingConstraint() {
+        String randomKey = UUID.randomUUID().toString();
+        String expectedViolationString = "Unrecognized constraints [" + randomKey + "]";
+        Map<String, String> invalidConstraintMap = ImmutableMap.of(randomKey, "test");
+        Set<ConstraintViolation<ConstraintMap>> violations = validator.validate(new ConstraintMap(invalidConstraintMap));
+        ConstraintViolation<ConstraintMap> constraintMapConstraintViolation = violations.stream().findFirst().orElseThrow(() -> new AssertionError("Expected violation not found"));
+        assertThat(constraintMapConstraintViolation.getMessage()).isEqualTo(expectedViolationString);
+    }
+
+    @Test
+    public void testRceAttemptInSchedulingConstraint() {
+        Map<String, String> invalidConstraintMap = ImmutableMap.of(EL_EXPRESSION_MESSAGE, "test");
+        Set<ConstraintViolation<ConstraintMap>> violations = validator.validate(new ConstraintMap(invalidConstraintMap));
+        ConstraintViolation<ConstraintMap> constraintMapConstraintViolation = violations.stream().findFirst().orElseThrow(() -> new AssertionError("Expected violation not found"));
+        assertThat(constraintMapConstraintViolation.getMessageTemplate()).isEqualTo(RCE_VIOLATION_MESSAGE);
+    }
+
+    static class ConstraintMap {
+
+        @SchedulingConstraintValidator.SchedulingConstraint
+        final Map<String, String> constraintMap;
+
+        public ConstraintMap(Map<String, String> map) {
+            this.constraintMap = map;
+        }
+    }
+}

--- a/titus-common/src/main/java/com/netflix/titus/common/model/sanitizer/internal/AbstractConstraintValidator.java
+++ b/titus-common/src/main/java/com/netflix/titus/common/model/sanitizer/internal/AbstractConstraintValidator.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.titus.common.model.sanitizer.internal;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+import java.lang.annotation.Annotation;
+
+public abstract class AbstractConstraintValidator<A extends Annotation, T> implements ConstraintValidator<A, T> {
+
+    @Override
+    final public boolean isValid(T type, ConstraintValidatorContext context) {
+        return this.isValid(type, new ConstraintValidatorContextWrapper(context));
+    }
+
+    abstract public boolean isValid(T type, ConstraintValidatorContextWrapper wrapper);
+
+}

--- a/titus-common/src/main/java/com/netflix/titus/common/model/sanitizer/internal/CollectionValidator.java
+++ b/titus-common/src/main/java/com/netflix/titus/common/model/sanitizer/internal/CollectionValidator.java
@@ -22,12 +22,10 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.stream.Collectors;
-import javax.validation.ConstraintValidator;
-import javax.validation.ConstraintValidatorContext;
 
 import com.netflix.titus.common.model.sanitizer.CollectionInvariants;
 
-public class CollectionValidator implements ConstraintValidator<CollectionInvariants, Object> {
+public class CollectionValidator extends AbstractConstraintValidator<CollectionInvariants, Object> {
 
     private CollectionInvariants constraintAnnotation;
 
@@ -37,7 +35,7 @@ public class CollectionValidator implements ConstraintValidator<CollectionInvari
     }
 
     @Override
-    public boolean isValid(Object value, ConstraintValidatorContext context) {
+    public boolean isValid(Object value, ConstraintValidatorContextWrapper context) {
         if (value == null) {
             return true;
         }
@@ -50,7 +48,7 @@ public class CollectionValidator implements ConstraintValidator<CollectionInvari
         return false;
     }
 
-    private boolean isValid(Collection<?> value, ConstraintValidatorContext context) {
+    private boolean isValid(Collection<?> value, ConstraintValidatorContextWrapper context) {
         if (value.isEmpty()) {
             return true;
         }
@@ -65,7 +63,7 @@ public class CollectionValidator implements ConstraintValidator<CollectionInvari
         return true;
     }
 
-    private boolean isValid(Map<?, ?> value, ConstraintValidatorContext context) {
+    private boolean isValid(Map<?, ?> value, ConstraintValidatorContextWrapper context) {
         if (value.isEmpty()) {
             return true;
         }
@@ -98,8 +96,7 @@ public class CollectionValidator implements ConstraintValidator<CollectionInvari
         return true;
     }
 
-    private void attachMessage(ConstraintValidatorContext context, String message) {
-        context.buildConstraintViolationWithTemplate(message).addConstraintViolation();
-        context.disableDefaultConstraintViolation();
+    private void attachMessage(ConstraintValidatorContextWrapper context, String message) {
+        context.buildConstraintViolationWithStaticMessage(message).addConstraintViolation().disableDefaultConstraintViolation();
     }
 }

--- a/titus-common/src/main/java/com/netflix/titus/common/model/sanitizer/internal/ConstraintValidatorContextWrapper.java
+++ b/titus-common/src/main/java/com/netflix/titus/common/model/sanitizer/internal/ConstraintValidatorContextWrapper.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.titus.common.model.sanitizer.internal;
+
+import javax.validation.ConstraintValidatorContext;
+
+public class ConstraintValidatorContextWrapper {
+
+    private final ConstraintValidatorContext constraintValidatorContext;
+
+    /**
+     * Escape all special characters that participate in EL expressions so the the message string
+     * cannot be classified as a template for interpolation.
+     *
+     * @param message string that needs to be sanitized
+     * @return copy of the input string with '{','}','#' and '$' characters escaped
+     */
+    private static String sanitizeMessage(String message) {
+        return message.replaceAll("([}{$#])", "\\\\$1");
+    }
+
+    public ConstraintValidatorContextWrapper(ConstraintValidatorContext context) {
+        this.constraintValidatorContext = context;
+    }
+
+    public ConstraintValidatorContext.ConstraintViolationBuilder buildConstraintViolationWithStaticMessage(String message) {
+        String sanitizedMessage = sanitizeMessage(message);
+        return this.constraintValidatorContext.buildConstraintViolationWithTemplate(sanitizedMessage);
+    }
+}

--- a/titus-common/src/main/java/com/netflix/titus/common/model/sanitizer/internal/NeverNullValidator.java
+++ b/titus-common/src/main/java/com/netflix/titus/common/model/sanitizer/internal/NeverNullValidator.java
@@ -20,26 +20,23 @@ import java.lang.reflect.Field;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
-import javax.validation.ConstraintValidator;
-import javax.validation.ConstraintValidatorContext;
 
 import com.netflix.titus.common.model.sanitizer.ClassFieldsNotNull;
 import com.netflix.titus.common.util.ReflectionExt;
 
-public class NeverNullValidator implements ConstraintValidator<ClassFieldsNotNull, Object> {
+public class NeverNullValidator extends AbstractConstraintValidator<ClassFieldsNotNull, Object> {
 
     @Override
     public void initialize(ClassFieldsNotNull constraintAnnotation) {
     }
 
     @Override
-    public boolean isValid(Object value, ConstraintValidatorContext context) {
+    public boolean isValid(Object value, ConstraintValidatorContextWrapper context) {
         Set<String> nullFields = validate(value);
         if (nullFields.isEmpty()) {
             return true;
         }
-        context.buildConstraintViolationWithTemplate(buildMessage(nullFields)).addConstraintViolation();
-        context.disableDefaultConstraintViolation();
+        context.buildConstraintViolationWithStaticMessage(buildMessage(nullFields)).addConstraintViolation().disableDefaultConstraintViolation();
         return false;
     }
 

--- a/titus-common/src/main/java/com/netflix/titus/common/model/sanitizer/internal/SpELClassValidator.java
+++ b/titus-common/src/main/java/com/netflix/titus/common/model/sanitizer/internal/SpELClassValidator.java
@@ -18,11 +18,10 @@ package com.netflix.titus.common.model.sanitizer.internal;
 
 import java.util.Map;
 import java.util.function.Supplier;
-import javax.validation.ConstraintValidator;
-import javax.validation.ConstraintValidatorContext;
 
 import com.netflix.titus.common.model.sanitizer.ClassInvariant;
 import com.netflix.titus.common.model.sanitizer.VerifierMode;
+import com.netflix.titus.common.util.CollectionsExt;
 import org.springframework.expression.EvaluationContext;
 import org.springframework.expression.Expression;
 import org.springframework.expression.ExpressionParser;
@@ -31,7 +30,7 @@ import org.springframework.expression.spel.standard.SpelExpressionParser;
 /**
  * Spring EL JavaBean validation framework class-level validator.
  */
-public class SpELClassValidator implements ConstraintValidator<ClassInvariant, Object> {
+public class SpELClassValidator extends AbstractConstraintValidator<ClassInvariant, Object> {
 
     private final ExpressionParser parser = new SpelExpressionParser();
     private final VerifierMode verifierMode;
@@ -61,7 +60,7 @@ public class SpELClassValidator implements ConstraintValidator<ClassInvariant, O
     }
 
     @Override
-    public boolean isValid(Object value, ConstraintValidatorContext context) {
+    public boolean isValid(Object value, ConstraintValidatorContextWrapper context) {
         if (!enabled) {
             return true;
         }
@@ -70,16 +69,14 @@ public class SpELClassValidator implements ConstraintValidator<ClassInvariant, O
         }
 
         Map<String, String> violations = (Map<String, String>) exprExpression.getValue(spelContext, value);
-        if (violations.isEmpty()) {
+        if (CollectionsExt.isNullOrEmpty(violations)) {
             return true;
         }
 
-        context.disableDefaultConstraintViolation();
-        violations.forEach((field, message) -> {
-            context.buildConstraintViolationWithTemplate(message)
-                    .addPropertyNode(field)
-                    .addConstraintViolation();
-        });
+        violations.forEach((field, message) -> context.buildConstraintViolationWithStaticMessage(message)
+                .addPropertyNode(field)
+                .addConstraintViolation()
+                .disableDefaultConstraintViolation());
 
         return false;
     }

--- a/titus-common/src/main/java/com/netflix/titus/common/model/sanitizer/internal/SpELFieldValidator.java
+++ b/titus-common/src/main/java/com/netflix/titus/common/model/sanitizer/internal/SpELFieldValidator.java
@@ -17,8 +17,6 @@
 package com.netflix.titus.common.model.sanitizer.internal;
 
 import java.util.function.Supplier;
-import javax.validation.ConstraintValidator;
-import javax.validation.ConstraintValidatorContext;
 
 import com.netflix.titus.common.model.sanitizer.FieldInvariant;
 import com.netflix.titus.common.model.sanitizer.VerifierMode;
@@ -27,7 +25,7 @@ import org.springframework.expression.Expression;
 import org.springframework.expression.ExpressionParser;
 import org.springframework.expression.spel.standard.SpelExpressionParser;
 
-public class SpELFieldValidator implements ConstraintValidator<FieldInvariant, Object> {
+public class SpELFieldValidator extends AbstractConstraintValidator<FieldInvariant, Object> {
 
     private final ExpressionParser parser = new SpelExpressionParser();
     private final VerifierMode verifierMode;
@@ -52,7 +50,7 @@ public class SpELFieldValidator implements ConstraintValidator<FieldInvariant, O
     }
 
     @Override
-    public boolean isValid(Object value, ConstraintValidatorContext context) {
+    public boolean isValid(Object value, ConstraintValidatorContextWrapper context) {
         if (!enabled) {
             return true;
         }


### PR DESCRIPTION
### Description of the Change

Sanitize message string so it is not an EL expression by escaping special characters.
The message string in this case is a collection of user supplied values which is being used as a part of message template for message interpolation.